### PR TITLE
make example dependant on local copy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - '8'
 install:
   - npm install -g ganache-cli truffle
+  - npm install
 before_script:
   - ganache-cli > /dev/null &
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
   - '8'
+install:
+  - npm install -g ganache-cli truffle
+before_script:
+  - ganache-cli > /dev/null &
 script:
   - npm run lint
   - truffle test

--- a/test/example.js
+++ b/test/example.js
@@ -1,6 +1,6 @@
 const Example = artifacts.require("ExampleContract")
 
-const { makeSnapshot, revertSnapshot } = require("ganache-snapshot")
+const { makeSnapshot, revertSnapshot } = require("../index.js")
 
 contract("ExampleContract", async () => {
   describe("incrementValue()", () => {

--- a/test/example.js
+++ b/test/example.js
@@ -1,6 +1,6 @@
 const Example = artifacts.require("ExampleContract")
 
-const { makeSnapshot, revertSnapshot } = require("../index.js")
+const { makeSnapshot, revertSnapshot } = require("../index.js")  // replace with "ganache-snapshot"
 
 contract("ExampleContract", async () => {
   describe("incrementValue()", () => {


### PR DESCRIPTION
We should not depend on our own package from an external source. This should make travis pass.